### PR TITLE
Keep source from the target spec

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,6 +9,8 @@ let
     neededNatives = [ pkgs.python ] ++ pkgs.lib.optional pkgs.stdenv.isLinux pkgs.utillinux;
     self = nodePackages;
     generated = ./node-packages.nix;
+    # Prevent magic overrides from getting applied.
+    overrides = { bower2nix = {}; };
   };
   getDrvs = with pkgs.stdenv.lib; pkgs: (filter (v: nixType v == "derivation") (attrValues pkgs));
   tarball = pkgs.runCommand "bower2nix-${version}.tgz" { buildInputs = [ pkgs.nodejs ]; } ''


### PR DESCRIPTION
Found that a target like "PolymerElements/font-roboto#^1.0.1" should
keep the source part also for the resolved version so that "fetch-bower"
can later successfully find the requested version.
